### PR TITLE
Circular single linked list 

### DIFF
--- a/include/circularsinglelinkedlist.h
+++ b/include/circularsinglelinkedlist.h
@@ -65,6 +65,27 @@ extern "C" {
 
 /******************************************************************
 *
+* FUNCTION NAME: create_list_csll       
+*
+* PURPOSE: Allocates the needed memory for a sentinel node of the circular singly linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the sentinel node to allocate
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void create_list_csll(void** list_sentinel_node);
+
+
+
+/******************************************************************
+*
 * FUNCTION NAME: create_node_csll       
 *
 * PURPOSE: Allocates the needed memory for a node of the singly linked list
@@ -121,7 +142,7 @@ void give_node_value_csll(void* node, void *value1, uint64_t size_of_datatype);
 *
 *
 *****************************************************************/
-void add_node_to_head_csll(void** head, void* node);
+void add_node_to_head_csll(void** list_sentinel_node, void* node);
 
 
 
@@ -142,7 +163,7 @@ void add_node_to_head_csll(void** head, void* node);
 *
 *
 *****************************************************************/
-void add_node_to_tail_csll(void** head, void* node);                  // ** needed in case head in null
+void add_node_to_tail_csll(void** list_sentinel_node, void* node);                  // ** needed in case head in null
 
 
 /******************************************************************
@@ -163,7 +184,7 @@ void add_node_to_tail_csll(void** head, void* node);                  // ** need
 *
 *
 *****************************************************************/
-void add_node_in_index_n_csll(void** head, void* node, uint64_t position);
+void add_node_in_index_n_csll(void** list_sentinel_node, void* node, uint64_t position);
 
 
 /******************************************************************
@@ -183,7 +204,7 @@ void add_node_in_index_n_csll(void** head, void* node, uint64_t position);
 *
 *
 *****************************************************************/
-void remove_head_node_csll(void** head);
+void remove_head_node_csll(void** list_sentinel_node);
 
 /******************************************************************
 *
@@ -202,7 +223,7 @@ void remove_head_node_csll(void** head);
 *
 *
 *****************************************************************/
-void remove_tail_node_csll(void** head);
+void remove_tail_node_csll(void** list_sentinel_node);
 
 /******************************************************************
 *
@@ -221,7 +242,7 @@ void remove_tail_node_csll(void** head);
 *
 *
 *****************************************************************/
-void remove_node_in_index_n_csll(void** head, uint64_t position);
+void remove_node_in_index_n_csll(void** list_sentinel_node, uint64_t position);
 
 /******************************************************************
 *
@@ -263,6 +284,26 @@ void* get_next_node_csll(void* node);
 
 /******************************************************************
 *
+* FUNCTION NAME: get_head_node       
+*
+* PURPOSE: returns a pointer to the head node of a list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I	pointer to the memory position of the node
+*
+*
+* RETURNS: void* (memory position of the next node to the given node )
+*
+*
+*
+*****************************************************************/
+void* get_head_node(void *list_sentinel_node);
+
+
+/******************************************************************
+*
 * FUNCTION NAME: get_value_csll       
 *
 * PURPOSE: Returns the memory position of the value that is currently in the given node
@@ -279,6 +320,7 @@ void* get_next_node_csll(void* node);
 *
 *****************************************************************/
 void* get_value_csll(void* node);
+
 
 /******************************************************************
 *
@@ -297,7 +339,7 @@ void* get_value_csll(void* node);
 *
 *
 *****************************************************************/
-void* get_value_in_index_n_csll(void* head, uint64_t n);
+void* get_value_in_index_n_csll(void* list_sentinel_node, uint64_t n);
 
 
 // get_head_value;
@@ -325,7 +367,7 @@ void* get_value_in_index_n_csll(void* head, uint64_t n);
 *
 *
 *****************************************************************/
-void free_linked_list_csll(void** head);
+void free_linked_list_csll(void** list_sentinel_node);
 
 
 /*****************************************************/

--- a/include/circularsinglelinkedlist.h
+++ b/include/circularsinglelinkedlist.h
@@ -1,0 +1,371 @@
+
+/*******************************************************************************************************
+* NAME: circularsinglelinkedlist.h                                                                        
+*                                                                                                       
+* PURPOSE: Defines a general template for circular single linked lists, including                                
+* the different needed functions                                                                        
+*                                                                                                       
+* GLOBAL VARIABLES: None                                                                                
+*                                                                                                       
+*                                                                                                       
+* DEVELOPMENT HISTORY:                                                                                  
+*                                                                                                       
+* Date          Author          Change Id       Release         Description Of Change                   
+* ----------    --------------- ---------       -------         -----------------------------------     
+* 02-06-2025    Tiago Rodrigues                       1         Initial commit 
+*                                                                                                       
+*******************************************************************************************************/
+#ifndef CIRCULARSINGLELINKEDLIST_H
+#define CIRCULARSINGLELINKEDLIST_H
+
+/* 0 copyright/licensing */
+/**********************************************************************
+*
+* 2024 Tiago Filipe Rodrigues tiagorodrigues1590@hotmail.com
+*
+***********************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/* 1 includes */
+/*****************************************************/
+#include <stdint.h>
+
+/*****************************************************/
+
+/* 2 defines */
+/*****************************************************/
+
+/*****************************************************/
+
+/* 3 external declarations */
+/*****************************************************/
+
+/*****************************************************/
+
+/* 4 typedefs */
+/*****************************************************/
+
+
+/*****************************************************/
+
+/* 5 global variable declarations */
+/*****************************************************/
+
+
+/*****************************************************/
+
+
+/* 6 function prototypes */
+/*****************************************************/
+
+/******************************************************************
+*
+* FUNCTION NAME: create_node_csll       
+*
+* PURPOSE: Allocates the needed memory for a node of the singly linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	TYPE	        I/O	DESCRIPTION
+* node	        void**	        I/O	pointer to the memory position of the node to allocate
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void create_node_csll(void** node);
+
+
+/******************************************************************
+*
+* FUNCTION NAME: give_node_value_csll       
+*
+* PURPOSE: Allocates and gives a value to a node already allocated
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I/O	pointer to the memory position of the node
+* value1                void*	        I	pointer to the memory position of the data to push into the node
+* size_of_datatype      uint64_t        I       byte size of datatype to place in the node
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void give_node_value_csll(void* node, void *value1, uint64_t size_of_datatype);
+
+
+/******************************************************************
+*
+* FUNCTION NAME: add_node_to_head_csll       
+*
+* PURPOSE: Adds a node to the head of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* node                  void*	        I	pointer to the memory position of the node to add to the list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void add_node_to_head_csll(void** head, void* node);
+
+
+
+/******************************************************************
+*
+* FUNCTION NAME: add_node_to_tail_csll       
+*
+* PURPOSE: Adds a node to the tail of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* node                  void*	        I	pointer to the memory position of the node to add to the list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void add_node_to_tail_csll(void** head, void* node);                  // ** needed in case head in null
+
+
+/******************************************************************
+*
+* FUNCTION NAME: add_node_in_index_n_csll       
+*
+* PURPOSE: Adds a node to index n of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* node                  void*	        I	pointer to the memory position of the node to add to the list
+* position              uint64_t        I       position to add node to the linked list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void add_node_in_index_n_csll(void** head, void* node, uint64_t position);
+
+
+/******************************************************************
+*
+* FUNCTION NAME: remove_head_node_csll       
+*
+* PURPOSE: removes the head of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void remove_head_node_csll(void** head);
+
+/******************************************************************
+*
+* FUNCTION NAME: remove_tail_node_csll       
+*
+* PURPOSE: removes the tail of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void remove_tail_node_csll(void** head);
+
+/******************************************************************
+*
+* FUNCTION NAME: remove_node_in_index_n_csll       
+*
+* PURPOSE: removes node at index n of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* position              uint64_t        I       position to remove node in the linked list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void remove_node_in_index_n_csll(void** head, uint64_t position);
+
+/******************************************************************
+*
+* FUNCTION NAME: next_node_csll       
+*
+* PURPOSE: changes pointer to the next node of that pointer
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void**	        I/O	pointer to the memory position of the node
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void next_node_csll(void** node);
+
+/******************************************************************
+*
+* FUNCTION NAME: get_next_node_csll       
+*
+* PURPOSE: returns a pointer to the next node of a node
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I	pointer to the memory position of the node
+*
+*
+* RETURNS: void* (memory position of the next node to the given node )
+*
+*
+*
+*****************************************************************/
+void* get_next_node_csll(void* node);
+
+/******************************************************************
+*
+* FUNCTION NAME: get_value_csll       
+*
+* PURPOSE: Returns the memory position of the value that is currently in the given node
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I	pointer to the memory position of the node
+*
+*
+* RETURNS: void* (pointer to the memory position of the value in the node)
+*
+*
+*
+*****************************************************************/
+void* get_value_csll(void* node);
+
+/******************************************************************
+*
+* FUNCTION NAME: get_value_in_index_n_csll       
+*
+* PURPOSE: Returns the memory position of the value that is currently in the node in index n
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void*	        I	pointer to the memory position of the head of the list
+* position              uint64_t        I       position of the node to return value
+*
+* RETURNS: void* (pointer to the memory position of the value in the node at index n)
+*
+*
+*
+*****************************************************************/
+void* get_value_in_index_n_csll(void* head, uint64_t n);
+
+
+// get_head_value;
+
+// get_tail_value;
+
+
+// void print_list(void* head);
+
+
+/******************************************************************
+*
+* FUNCTION NAME: free_linked_list_csll       
+*
+* PURPOSE: frees a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void free_linked_list_csll(void** head);
+
+
+/*****************************************************/
+
+
+
+/* 7 function declarations */
+/*****************************************************/
+
+/*****************************************************/
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/linked-lists/circularsinglelinkedlist.c
+++ b/src/linked-lists/circularsinglelinkedlist.c
@@ -1,0 +1,718 @@
+/*******************************************************************************************************************
+* FILE NAME: circularsinglelinkedlist.c
+*                                                                                                               
+* PURPOSE: This file implements all the functions needed for the creation and modification of a circular single linked list
+*                                                                                                               
+* FILE REFERENCES:                                                                                              
+*                                                                                                               
+* Name                          I/O                     Description                                             
+* ----                          ---                     -----------                                             
+* none     
+                                                                                                          
+* EXTERNAL VARIABLES:                                                                                           
+*                                                                                        
+*                                                                                                               
+* Name          Type            I/O                     Description                                             
+* ----          ----            ---                     -----------                                             
+* none
+*
+*                                                                                                             
+* EXTERNAL REFERENCES:                                                                                          
+* Name                          Description                                                                     
+* ----                          -----------                                                                     
+* calloc                        allocates memory, and initiates with zeros     
+* printf                        function to print formatted output     
+*    
+* ABNORMAL TERMINATION CONDITIONS, ERROR AND WARNING MESSAGES:                                                  
+*             
+*                                                                                                  
+* ASSUMPTIONS, CONSTRAINTS, RESTRICTIONS:                                                                       
+* It is assumed that the list is less than 2^64 elements, for input at                                          
+*  a especific position operations          
+* It is assumed for list insertion that it starts at index 0, and if n is larger than the list,
+*  it is added to the end  
+                                                                                                                
+* NOTES:                                                                                                        
+* If more that 2^64 is needed, use arbitrary-precision arithmetic libs                                  
+*                                       
+* REQUIREMENTS/FUNCTIONAL SPECIFICATIONS REFERENCES:                                                            
+*
+*                                                                                                               
+* DEVELOPMENT HISTORY:                                                                                          
+*                                                                                                               
+* Date          Author                  Change Id       Release         Description Of Change                   
+* ----------    ---------------         ---------       -------         ---------------------   
+* 02-06-2025    Tiago Rodrigues                         1               Initial commit
+*                                                                                                              
+* ALGORITHM (PDL)
+*    
+*
+*                                                                                                           
+****************************************************************************************************************/
+
+
+/* 0 copyright/licensing */
+/***************************************************************************************************************/
+/*
+*       2024 Tiago Filipe Rodrigues tiagorodrigues1590@hotmail.com
+*/
+/***************************************************************************************************************/
+
+
+/* 1 includes */
+/*****************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "circularsinglelinkedlist.h"
+/*****************************************************/
+
+
+/* 2 defines */
+/*****************************************************/
+
+/*****************************************************/
+
+
+/* 3 external declarations */
+/*****************************************************/
+
+/*****************************************************/
+
+
+/* 4 typedefs */
+/*****************************************************/
+
+/*****************************************************/
+
+
+/* 5 global variable declarations */
+/*****************************************************/
+struct node
+{
+        struct node* tail;                                              // TODO: create sentinel nodes, this is way too much allocation
+        // uint64_t size_of_datatype;                   not needed, unless trying to make a multi value linked list
+        void* data;
+        struct node* next;
+};
+
+
+
+
+
+/*****************************************************/
+
+
+/* 6 function prototypes */
+/*****************************************************/
+
+/*****************************************************/
+
+
+
+/* 7 function declarations */
+/*****************************************************/
+
+
+/******************************************************************
+*
+* FUNCTION NAME: create_node_csll       
+*
+* PURPOSE: Allocates the needed memory for a node of the singly linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	TYPE	        I/O	DESCRIPTION
+* node	        void**	        I/O	pointer to the memory position of the node to allocate
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void create_node_csll(void** node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */
+        (*node) = malloc(1*sizeof(struct node));
+        if(NULL == (*node))
+        {
+                fprintf(stderr, "Memory allocation failed\n");
+                return ;
+        }
+        (*(struct node **)(node))->next = NULL;
+        
+        (*(struct node **)(node))->tail = NULL;
+        
+        return ;
+}
+
+
+/******************************************************************
+*
+* FUNCTION NAME: give_node_value_csll       
+*
+* PURPOSE: Allocates and gives a value to a node already allocated
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I/O	pointer to the memory position of the node
+* value1                void*	        I	pointer to the memory position of the data to push into the node
+* size_of_datatype      uint64_t        I       byte size of datatype to place in the node
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void give_node_value_csll(void* node, void *value1, uint64_t size_of_datatype)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */
+        if(NULL == node)
+        {
+                fprintf(stderr, "Node mem location is null\n");
+                return ;
+        }
+
+        ((struct node*)node)->data =(void*) malloc(1*size_of_datatype);
+
+        if(NULL == ((struct node*)node)->data)
+        {
+                fprintf(stderr, "Memory allocation failed\n");
+        }
+
+        memcpy(((struct node*)node)->data, value1, size_of_datatype);
+
+        return ;
+}
+
+
+/******************************************************************
+*
+* FUNCTION NAME: add_node_to_head_csll       
+*
+* PURPOSE: Adds a node to the head of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* node                  void*	        I	pointer to the memory position of the node to add to the list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void add_node_to_head_csll(void** head, void* node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */
+        if(NULL == (*head))
+        {
+                (*head) = node;
+                ((struct node*)node)->tail = node;
+                return;
+        }
+        if(NULL == node)
+        {
+                return;
+        }
+
+        ((struct node*)node)->next= ((struct node*)(*head));
+
+        
+        if(NULL != ((struct node*)(*head))->tail)
+        {
+                ((struct node*)node)->tail = ((struct node*)(*head))->tail;
+                ((struct node*)(*head))->tail = NULL;
+                
+        }
+        else                            // first insertion
+        {
+
+                ((struct node*)node)->tail = ((struct node*)(*head));
+        }
+
+        ((struct node*)node)->tail->next = ((struct node*)node);
+
+        (*head) = node;
+
+}
+
+/******************************************************************
+*
+* FUNCTION NAME: add_node_to_tail_csll       
+*
+* PURPOSE: Adds a node to the tail of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* node                  void*	        I	pointer to the memory position of the node to add to the list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void add_node_to_tail_csll(void** head, void* node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable     Type            Description
+        *  --------     ----            -----------
+        *  None      
+        */
+        if(NULL == (*head))
+        {
+                (*head) = node;
+                ((struct node*)node)->tail = node;
+                return;
+        }
+        if(NULL == node)
+        {
+                return;
+        }
+        
+        if (NULL != ((struct node*)(*head))->tail)
+        {
+                 ((struct node*)(*head))->tail->next = node;
+        }
+        
+
+        ((struct node*)(*head))->tail = node;
+        ((struct node*)node)->next = (*head);
+
+        return;
+
+}
+
+/******************************************************************
+*
+* FUNCTION NAME: add_node_in_index_n_csll       
+*
+* PURPOSE: Adds a node to index n of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* node                  void*	        I	pointer to the memory position of the node to add to the list
+* position              uint64_t        I       position to add node to the linked list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void add_node_in_index_n_csll(void** head, void* node, uint64_t position)
+{
+        /* LOCAL VARIABLES:
+        *  Variable     Type            Description
+        *  --------     ----            -----------
+        *  aux_ptr      struct node*    auxiliary node to walk through the list         
+        */        
+        if(NULL == (*head))
+        {
+                (*head) = node;
+                ((struct node*)node)->tail = node;
+                return;
+        }
+        if(NULL == node)
+        {
+                return;
+        }
+        if(0 == position)
+        {
+                add_node_to_head_csll(head, node);
+                return ;
+        }
+
+        struct node* aux_ptr = (*(struct node**)(head));
+        while((*head) != get_next_node_csll((void *)aux_ptr) && position>1)                     //has to be 1
+        {
+                next_node_csll((void**) &aux_ptr);
+                position--;
+        }
+
+        if((*head) == get_next_node_csll((void *)aux_ptr))
+        {
+                add_node_to_tail_csll(head,node);
+        }
+        else
+        {
+                ((struct node*)node)->next= aux_ptr->next;
+                aux_ptr->next =((struct node*)node);
+        }
+
+        return;
+}
+
+/******************************************************************
+*
+* FUNCTION NAME: remove_head_node_csll       
+*
+* PURPOSE: removes the head of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void remove_head_node_csll(void** head)
+{
+        /* LOCAL VARIABLES:
+        *  Variable     Type            Description
+        *  --------     ----            -----------
+        *  aux_ptr      struct node*    auxiliary pointer to node to free         
+        */        
+        if(NULL == (*head))
+        {
+                return;
+        }
+
+        struct node* aux_ptr = (*(struct node**)(head));
+
+        //if(NULL == ((struct node*)(*head))->next)
+        //{
+
+        //}
+
+        ((struct node*)(*head))->next->tail = ((struct node*)(*head))->tail;
+        ((struct node*)(*head))->tail->next = ((struct node*)(*head))->next;
+
+        next_node_csll(head);
+
+        free(aux_ptr->data);
+        free(aux_ptr);
+
+        return;
+
+}
+
+/******************************************************************
+*
+* FUNCTION NAME: remove_tail_node_csll       
+*
+* PURPOSE: removes the tail of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void remove_tail_node_csll(void** head)
+{
+        /* LOCAL VARIABLES:
+        *  Variable     Type            Description
+        *  --------     ----            -----------
+        *  aux_ptr      struct node*    auxiliary pointer to node to free and for walking through the list         
+        */
+        if(NULL == (*head))
+        {
+                return;
+        }
+        if(NULL == (*(struct node**)(head))->next)
+        {
+                free((*(struct node**)(head))->data);
+                free((*head));
+                (*head) = NULL;
+                return;
+        }
+
+        struct node* aux_ptr = (*(struct node**)(head));
+        while(((struct node*)(*head))->tail != get_next_node_csll((void *)aux_ptr))
+        {
+                
+                next_node_csll((void**) &aux_ptr);
+
+
+        }
+        ((struct node*)(*head))->tail = aux_ptr;
+
+        aux_ptr = aux_ptr->next;
+        //free(get_value(get_next_node_csll((void *)aux_ptr)));
+        free(aux_ptr->data);
+        //free(get_next_node_csll((void *)aux_ptr));
+        free(aux_ptr);
+
+        ((struct node*)(*head))->tail->next = ((struct node*)(*head));
+
+        
+
+        return;
+
+
+}
+
+
+/******************************************************************
+*
+* FUNCTION NAME: remove_node_in_index_n_csll       
+*
+* PURPOSE: removes node at index n of a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+* position              uint64_t        I       position to remove node in the linked list
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void remove_node_in_index_n_csll(void** head, uint64_t position)
+{
+        /* LOCAL VARIABLES:
+        *  Variable     Type            Description
+        *  --------     ----            -----------
+        *  aux_ptr      struct node*    auxiliary pointer to node to free and for walking through the list         
+        */
+        if(NULL == (*head))
+        {
+                return;
+        }
+        if(0 == position)
+        {
+                remove_head_node_csll(head);
+                return ;
+        }
+
+        struct node* aux_ptr = (*(struct node**)(head));
+        while(((struct node*)(*head)) != get_next_node_csll((void *)aux_ptr) && position>1)                     //has to be 1
+        {
+                next_node_csll((void**) &aux_ptr);
+                position--;
+        }
+
+        if(((struct node*)(*head)) == get_next_node_csll((void *)aux_ptr))
+                return ;
+
+        if(((struct node*)(*head))->tail != get_next_node_csll((void *)aux_ptr))
+        {
+                remove_tail_node_csll(head);
+        }
+
+        if(1 == position)
+        {
+                struct node* node_to_free = NULL;
+                node_to_free = get_next_node_csll((void *)aux_ptr);
+                aux_ptr->next = node_to_free->next;
+        
+                free(node_to_free->data);
+                free(node_to_free);
+        }
+
+        return ;
+}
+
+
+/******************************************************************
+*
+* FUNCTION NAME: next_node_csll       
+*
+* PURPOSE: changes pointer to the next node of that pointer
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void**	        I/O	pointer to the memory position of the node
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void next_node_csll(void** node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */
+        (*(struct node**)(node)) = get_next_node_csll((*(struct node**)(node)));
+        return;
+}
+
+
+/******************************************************************
+*
+* FUNCTION NAME: get_next_node_csll       
+*
+* PURPOSE: returns a pointer to the next node of a node
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I	pointer to the memory position of the node
+*
+*
+* RETURNS: void* (memory position of the next node to the given node )
+*
+*
+*
+*****************************************************************/
+void* get_next_node_csll(void* node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */        
+        if(NULL == node)
+                return NULL;
+
+        return ((void *)((struct node*)node)->next);              
+}
+
+/******************************************************************
+*
+* FUNCTION NAME: get_value_csll       
+*
+* PURPOSE: Returns the memory position of the value that is currently in the given node
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I	pointer to the memory position of the node
+*
+*
+* RETURNS: void* (pointer to the memory position of the value in the node)
+*
+*
+*
+*****************************************************************/
+void* get_value_csll(void* node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */
+        if(NULL == node)
+                return NULL;
+        return ((struct node*)node)->data;
+}
+
+
+
+/******************************************************************
+*
+* FUNCTION NAME: get_value_in_index_n_csll       
+*
+* PURPOSE: Returns the memory position of the value that is currently in the node in index n
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void*	        I	pointer to the memory position of the head of the list
+* position              uint64_t        I       position of the node to return value
+*
+* RETURNS: void* (pointer to the memory position of the value in the node at index n)
+*
+*
+*
+*****************************************************************/
+void* get_value_in_index_n_csll(void* head, uint64_t n)
+{
+        /* LOCAL VARIABLES:
+        *  Variable     Type            Description
+        *  --------     ----            -----------
+        *  aux_ptr      struct node*    auxiliary pointer to node for walking through the list         
+        */
+        if(NULL == (head))
+        {
+                return NULL;
+        }
+
+        struct node* aux_ptr = ((struct node*)(head));
+        
+
+        while(NULL != get_next_node_csll((void *)aux_ptr) && n>0)                  
+        {
+                next_node_csll((void**) &aux_ptr);
+                n--;
+        }
+
+        if(0 != n)
+                return NULL;
+        
+        return aux_ptr->data;
+}
+
+// void print_list(void* head);
+
+
+/******************************************************************
+*
+* FUNCTION NAME: free_linked_list_csll       
+*
+* PURPOSE: frees a linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* head	                void**	        I/O	pointer to the memory position of the head of the list
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void  free_linked_list_csll(void** head)
+{
+        /* LOCAL VARIABLES:
+        *  Variable     Type            Description
+        *  --------     ----            -----------
+        *  aux_ptr      struct node*    auxiliary pointer to a node to free         
+        */  
+        ((struct node*)(*head))->tail->next = NULL;
+        while(NULL != (*head))
+        {
+                struct node* aux_ptr = (*head);
+                (*head) = get_next_node_csll((*head));
+                free(aux_ptr->data);
+                free(aux_ptr);
+        }
+        head = NULL;
+        return ;
+}
+
+
+
+/*****************************************************/
+
+
+
+
+

--- a/src/linked-lists/circularsinglelinkedlist.c
+++ b/src/linked-lists/circularsinglelinkedlist.c
@@ -99,6 +99,15 @@ struct node
 
 
 
+struct sentinel_node
+{
+        struct node* tail;                                              // TODO: create sentinel nodes, this is way too much allocation
+        struct node* head;
+};
+
+
+
+
 
 
 /*****************************************************/
@@ -113,6 +122,43 @@ struct node
 
 /* 7 function declarations */
 /*****************************************************/
+
+/******************************************************************
+*
+* FUNCTION NAME: create_list_csll       
+*
+* PURPOSE: Allocates the needed memory for a sentinel node of the circular singly linked list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the sentinel node to allocate
+*
+*
+* RETURNS: void
+*
+*
+*
+*****************************************************************/
+void create_list_csll(void** list_sentinel_node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */
+        (*list_sentinel_node) = malloc(1*sizeof(struct sentinel_node));
+        if(NULL == (*list_sentinel_node))
+        {
+                fprintf(stderr, "Memory allocation failed\n");
+                return ;
+        }
+        (*(struct sentinel_node **)(list_sentinel_node))->head = NULL;
+        
+        (*(struct sentinel_node **)(list_sentinel_node))->tail = NULL;
+        
+        return ;
+}
 
 
 /******************************************************************
@@ -206,7 +252,7 @@ void give_node_value_csll(void* node, void *value1, uint64_t size_of_datatype)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void**	        I/O	pointer to the memory position of the head of the list
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the head of the list
 * node                  void*	        I	pointer to the memory position of the node to add to the list
 *
 * RETURNS: void
@@ -214,17 +260,20 @@ void give_node_value_csll(void* node, void *value1, uint64_t size_of_datatype)
 *
 *
 *****************************************************************/
-void add_node_to_head_csll(void** head, void* node)
+void add_node_to_head_csll(void** list_sentinel_node, void* node)
 {
         /* LOCAL VARIABLES:
         *  Variable        Type    Description
         *  --------        ----    -----------
         *  None
         */
-        if(NULL == (*head))
+        if(NULL == (*list_sentinel_node))
         {
-                (*head) = node;
-                ((struct node*)node)->tail = node;
+                create_list_csll(list_sentinel_node);
+
+                (*(struct sentinel_node **)(list_sentinel_node))->head = node;
+                (*(struct sentinel_node **)(list_sentinel_node))->tail = node;
+
                 return;
         }
         if(NULL == node)
@@ -232,24 +281,14 @@ void add_node_to_head_csll(void** head, void* node)
                 return;
         }
 
-        ((struct node*)node)->next= ((struct node*)(*head));
-
+        ((struct node*)node)->next= (*(struct sentinel_node **)(list_sentinel_node))->head;
+        (*(struct sentinel_node **)(list_sentinel_node))->head = node;
         
-        if(NULL != ((struct node*)(*head))->tail)
+        if(NULL == (*(struct sentinel_node **)(list_sentinel_node))->tail)
         {
-                ((struct node*)node)->tail = ((struct node*)(*head))->tail;
-                ((struct node*)(*head))->tail = NULL;
+                (*(struct sentinel_node **)(list_sentinel_node))->tail = node;
                 
         }
-        else                            // first insertion
-        {
-
-                ((struct node*)node)->tail = ((struct node*)(*head));
-        }
-
-        ((struct node*)node)->tail->next = ((struct node*)node);
-
-        (*head) = node;
 
 }
 
@@ -262,7 +301,7 @@ void add_node_to_head_csll(void** head, void* node)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void**	        I/O	pointer to the memory position of the head of the list
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the head of the list
 * node                  void*	        I	pointer to the memory position of the node to add to the list
 *
 * RETURNS: void
@@ -270,32 +309,36 @@ void add_node_to_head_csll(void** head, void* node)
 *
 *
 *****************************************************************/
-void add_node_to_tail_csll(void** head, void* node)
+void add_node_to_tail_csll(void** list_sentinel_node, void* node)
 {
         /* LOCAL VARIABLES:
         *  Variable     Type            Description
         *  --------     ----            -----------
         *  None      
         */
-        if(NULL == (*head))
+        if(NULL == (*list_sentinel_node))
         {
-                (*head) = node;
-                ((struct node*)node)->tail = node;
+                create_list_csll(list_sentinel_node);
+
+                (*(struct sentinel_node **)(list_sentinel_node))->head = node;
+                (*(struct sentinel_node **)(list_sentinel_node))->tail = node;
+
                 return;
         }
         if(NULL == node)
         {
                 return;
         }
+
         
-        if (NULL != ((struct node*)(*head))->tail)
+        if (NULL != (*(struct sentinel_node **)(list_sentinel_node))->tail)
         {
-                 ((struct node*)(*head))->tail->next = node;
+                 (*(struct sentinel_node **)(list_sentinel_node))->tail->next = node;
         }
         
 
-        ((struct node*)(*head))->tail = node;
-        ((struct node*)node)->next = (*head);
+        (*(struct sentinel_node **)(list_sentinel_node))->tail = node;
+        ((struct node*)node)->next = (*(struct sentinel_node **)(list_sentinel_node))->head;
 
         return;
 
@@ -310,7 +353,7 @@ void add_node_to_tail_csll(void** head, void* node)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void**	        I/O	pointer to the memory position of the head of the list
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the head of the list
 * node                  void*	        I	pointer to the memory position of the node to add to the list
 * position              uint64_t        I       position to add node to the linked list
 *
@@ -319,39 +362,45 @@ void add_node_to_tail_csll(void** head, void* node)
 *
 *
 *****************************************************************/
-void add_node_in_index_n_csll(void** head, void* node, uint64_t position)
+void add_node_in_index_n_csll(void** list_sentinel_node, void* node, uint64_t position)
 {
         /* LOCAL VARIABLES:
         *  Variable     Type            Description
         *  --------     ----            -----------
         *  aux_ptr      struct node*    auxiliary node to walk through the list         
-        */        
-        if(NULL == (*head))
+        */      
+         if(NULL == (*list_sentinel_node))
         {
-                (*head) = node;
-                ((struct node*)node)->tail = node;
+                create_list_csll(list_sentinel_node);
+
+                (*(struct sentinel_node **)(list_sentinel_node))->head = node;
+                (*(struct sentinel_node **)(list_sentinel_node))->tail = node;
+
                 return;
         }
         if(NULL == node)
         {
                 return;
-        }
+        }      
         if(0 == position)
         {
-                add_node_to_head_csll(head, node);
+                add_node_to_head_csll(list_sentinel_node, node);
                 return ;
         }
 
-        struct node* aux_ptr = (*(struct node**)(head));
-        while((*head) != get_next_node_csll((void *)aux_ptr) && position>1)                     //has to be 1
+        struct node* aux_ptr = (*(struct node**)((*(struct sentinel_node **)(list_sentinel_node))->head));
+        struct node* aux_head = (*(struct node**)((*(struct sentinel_node **)(list_sentinel_node))->head));
+
+
+        while(aux_head != get_next_node_csll((void *)aux_ptr) && position>1)                     //has to be 1
         {
                 next_node_csll((void**) &aux_ptr);
                 position--;
         }
 
-        if((*head) == get_next_node_csll((void *)aux_ptr))
+        if(aux_head == get_next_node_csll((void *)aux_ptr))
         {
-                add_node_to_tail_csll(head,node);
+                add_node_to_tail_csll(list_sentinel_node,node);
         }
         else
         {
@@ -371,7 +420,7 @@ void add_node_in_index_n_csll(void** head, void* node, uint64_t position)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void**	        I/O	pointer to the memory position of the head of the list
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the head of the list
 *
 *
 * RETURNS: void
@@ -379,29 +428,25 @@ void add_node_in_index_n_csll(void** head, void* node, uint64_t position)
 *
 *
 *****************************************************************/
-void remove_head_node_csll(void** head)
+void remove_head_node_csll(void** list_sentinel_node)
 {
         /* LOCAL VARIABLES:
         *  Variable     Type            Description
         *  --------     ----            -----------
         *  aux_ptr      struct node*    auxiliary pointer to node to free         
         */        
-        if(NULL == (*head))
+        if(NULL == (*list_sentinel_node))
         {
                 return;
         }
 
-        struct node* aux_ptr = (*(struct node**)(head));
+        struct node* aux_ptr = (*(struct node**)((*(struct sentinel_node **)(list_sentinel_node))->head));
 
-        //if(NULL == ((struct node*)(*head))->next)
-        //{
 
-        //}
 
-        ((struct node*)(*head))->next->tail = ((struct node*)(*head))->tail;
-        ((struct node*)(*head))->tail->next = ((struct node*)(*head))->next;
+        ((*(struct sentinel_node **)(list_sentinel_node))->head) = ((*(struct sentinel_node **)(list_sentinel_node))->head)->next;
+        ((*(struct sentinel_node **)(list_sentinel_node))->tail)->next = ((*(struct sentinel_node **)(list_sentinel_node))->head); // TODO: problems with next being node?
 
-        next_node_csll(head);
 
         free(aux_ptr->data);
         free(aux_ptr);
@@ -419,7 +464,7 @@ void remove_head_node_csll(void** head)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void**	        I/O	pointer to the memory position of the head of the list
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the head of the list
 *
 *
 * RETURNS: void
@@ -427,34 +472,41 @@ void remove_head_node_csll(void** head)
 *
 *
 *****************************************************************/
-void remove_tail_node_csll(void** head)
+void remove_tail_node_csll(void** list_sentinel_node)
 {
         /* LOCAL VARIABLES:
         *  Variable     Type            Description
         *  --------     ----            -----------
         *  aux_ptr      struct node*    auxiliary pointer to node to free and for walking through the list         
         */
-        if(NULL == (*head))
+        if(NULL == (*list_sentinel_node))
         {
                 return;
         }
-        if(NULL == (*(struct node**)(head))->next)
+        if(NULL == ((*(struct sentinel_node **)(list_sentinel_node))->head)->next)
         {
-                free((*(struct node**)(head))->data);
-                free((*head));
-                (*head) = NULL;
+
+                free(((*(struct sentinel_node **)(list_sentinel_node))->head)->data);
+                free(((*(struct sentinel_node **)(list_sentinel_node))->head));
+
+                ((*(struct sentinel_node **)(list_sentinel_node))->head) = NULL;
+                ((*(struct sentinel_node **)(list_sentinel_node))->tail) = NULL;
                 return;
         }
 
-        struct node* aux_ptr = (*(struct node**)(head));
-        while(((struct node*)(*head))->tail != get_next_node_csll((void *)aux_ptr))
+        struct node* aux_ptr = ((*(struct sentinel_node **)(list_sentinel_node))->head);
+
+        while(((*(struct sentinel_node **)(list_sentinel_node))->tail) != get_next_node_csll((void *)aux_ptr))
         {
                 
                 next_node_csll((void**) &aux_ptr);
 
 
         }
-        ((struct node*)(*head))->tail = aux_ptr;
+        
+
+        (*(struct sentinel_node **)(list_sentinel_node))->tail = aux_ptr;
+
 
         aux_ptr = aux_ptr->next;
         //free(get_value(get_next_node_csll((void *)aux_ptr)));
@@ -462,9 +514,8 @@ void remove_tail_node_csll(void** head)
         //free(get_next_node_csll((void *)aux_ptr));
         free(aux_ptr);
 
-        ((struct node*)(*head))->tail->next = ((struct node*)(*head));
-
-        
+        (*(struct sentinel_node **)(list_sentinel_node))->tail->next = ((*(struct sentinel_node **)(list_sentinel_node))->head);
+    
 
         return;
 
@@ -481,7 +532,7 @@ void remove_tail_node_csll(void** head)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void**	        I/O	pointer to the memory position of the head of the list
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the head of the list
 * position              uint64_t        I       position to remove node in the linked list
 *
 * RETURNS: void
@@ -489,36 +540,38 @@ void remove_tail_node_csll(void** head)
 *
 *
 *****************************************************************/
-void remove_node_in_index_n_csll(void** head, uint64_t position)
+void remove_node_in_index_n_csll(void** list_sentinel_node, uint64_t position)
 {
         /* LOCAL VARIABLES:
         *  Variable     Type            Description
         *  --------     ----            -----------
         *  aux_ptr      struct node*    auxiliary pointer to node to free and for walking through the list         
         */
-        if(NULL == (*head))
+        if(NULL == (*list_sentinel_node))
         {
                 return;
         }
         if(0 == position)
         {
-                remove_head_node_csll(head);
+                remove_head_node_csll(list_sentinel_node);
                 return ;
         }
 
-        struct node* aux_ptr = (*(struct node**)(head));
-        while(((struct node*)(*head)) != get_next_node_csll((void *)aux_ptr) && position>1)                     //has to be 1
+        struct node* aux_ptr = ((*(struct sentinel_node **)(list_sentinel_node))->head);
+
+
+        while(((*(struct sentinel_node **)(list_sentinel_node))->head) != get_next_node_csll((void *)aux_ptr) && position>1)                     //has to be 1
         {
                 next_node_csll((void**) &aux_ptr);
                 position--;
         }
 
-        if(((struct node*)(*head)) == get_next_node_csll((void *)aux_ptr))
+        if(((*(struct sentinel_node **)(list_sentinel_node))->head) == get_next_node_csll((void *)aux_ptr))
                 return ;
 
-        if(((struct node*)(*head))->tail != get_next_node_csll((void *)aux_ptr))
+        if(((*(struct sentinel_node **)(list_sentinel_node))->tail) != get_next_node_csll((void *)aux_ptr))
         {
-                remove_tail_node_csll(head);
+                remove_tail_node_csll(list_sentinel_node);
         }
 
         if(1 == position)
@@ -627,6 +680,39 @@ void* get_value_csll(void* node)
 
 /******************************************************************
 *
+* FUNCTION NAME: get_head_node       
+*
+* PURPOSE: returns a pointer to the head node of a list
+*
+* ARGUMENTS:
+*
+* ARGUMENT 	        TYPE	        I/O	DESCRIPTION
+* node	                void*	        I	pointer to the memory position of the node
+*
+*
+* RETURNS: void* (memory position of the next node to the given node )
+*
+*
+*
+*****************************************************************/
+void* get_head_node(void *list_sentinel_node)
+{
+        /* LOCAL VARIABLES:
+        *  Variable        Type    Description
+        *  --------        ----    -----------
+        *  None
+        */
+        if(NULL == list_sentinel_node)
+                return NULL;
+
+        return ((void *)(((struct sentinel_node *)(list_sentinel_node))->head));           
+
+
+}
+
+
+/******************************************************************
+*
 * FUNCTION NAME: get_value_in_index_n_csll       
 *
 * PURPOSE: Returns the memory position of the value that is currently in the node in index n
@@ -634,7 +720,7 @@ void* get_value_csll(void* node)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void*	        I	pointer to the memory position of the head of the list
+* list_sentinel_node    void*	        I	pointer to the memory position of the head of the list
 * position              uint64_t        I       position of the node to return value
 *
 * RETURNS: void* (pointer to the memory position of the value in the node at index n)
@@ -642,19 +728,19 @@ void* get_value_csll(void* node)
 *
 *
 *****************************************************************/
-void* get_value_in_index_n_csll(void* head, uint64_t n)
+void* get_value_in_index_n_csll(void* list_sentinel_node, uint64_t n)
 {
         /* LOCAL VARIABLES:
         *  Variable     Type            Description
         *  --------     ----            -----------
         *  aux_ptr      struct node*    auxiliary pointer to node for walking through the list         
         */
-        if(NULL == (head))
+        if(NULL == (list_sentinel_node))
         {
                 return NULL;
         }
 
-        struct node* aux_ptr = ((struct node*)(head));
+        struct node* aux_ptr = (((struct sentinel_node *)(list_sentinel_node))->head);
         
 
         while(NULL != get_next_node_csll((void *)aux_ptr) && n>0)                  
@@ -681,7 +767,7 @@ void* get_value_in_index_n_csll(void* head, uint64_t n)
 * ARGUMENTS:
 *
 * ARGUMENT 	        TYPE	        I/O	DESCRIPTION
-* head	                void**	        I/O	pointer to the memory position of the head of the list
+* list_sentinel_node    void**	        I/O	pointer to the memory position of the head of the list
 *
 *
 * RETURNS: void
@@ -689,22 +775,26 @@ void* get_value_in_index_n_csll(void* head, uint64_t n)
 *
 *
 *****************************************************************/
-void  free_linked_list_csll(void** head)
+void  free_linked_list_csll(void** list_sentinel_node)
 {
         /* LOCAL VARIABLES:
         *  Variable     Type            Description
         *  --------     ----            -----------
         *  aux_ptr      struct node*    auxiliary pointer to a node to free         
         */  
-        ((struct node*)(*head))->tail->next = NULL;
-        while(NULL != (*head))
+        ((*(struct sentinel_node **)(list_sentinel_node))->tail)->next = NULL;
+        while(NULL !=  ((*(struct sentinel_node **)(list_sentinel_node))->head))
         {
-                struct node* aux_ptr = (*head);
-                (*head) = get_next_node_csll((*head));
+                struct node* aux_ptr = ((*(struct sentinel_node **)(list_sentinel_node))->head);
+                ((*(struct sentinel_node **)(list_sentinel_node))->head) = get_next_node_csll(((*(struct sentinel_node **)(list_sentinel_node))->head));
                 free(aux_ptr->data);
                 free(aux_ptr);
         }
-        head = NULL;
+        free((*(struct sentinel_node **)(list_sentinel_node)));
+        
+        (*(list_sentinel_node)) = NULL;
+        (list_sentinel_node) = NULL;
+        
         return ;
 }
 

--- a/tests/circularsinglelinkedlist_test.c
+++ b/tests/circularsinglelinkedlist_test.c
@@ -1,0 +1,199 @@
+
+
+#include "circularsinglelinkedlist.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+
+void simple_single_linked_list_test()
+{
+
+        void *head1 = NULL;
+        void *node1 = NULL;
+        uint32_t data1 = 2;
+
+        create_node_csll(&head1);
+
+
+        give_node_value_csll(head1,(void*) &data1,sizeof(uint32_t));
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+
+   
+
+        create_node_csll(&node1);
+        data1 = 3;
+        give_node_value_csll(node1,(void*) &data1,sizeof(uint32_t));
+
+        add_node_to_head_csll(&head1,node1);
+
+
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+     
+        remove_head_node_csll(&head1);
+
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+
+        remove_head_node_csll(&head1);
+        remove_head_node_csll(&head1);
+        remove_head_node_csll(&head1);
+
+        return ;
+}
+
+
+void simple_single_linked_list_test2()
+{
+
+        void *head1 = NULL;
+        void *node1 = NULL;
+        uint32_t data1 = 22;
+
+        create_node_csll(&head1);
+
+        give_node_value_csll(head1,(void*) &data1,sizeof(uint32_t));
+        // printf("%u\n", *((uint32_t*)get_value(head1)));
+
+   
+        for(int i=0;i<10;i++)
+        {
+                create_node_csll(&node1);
+                data1 = i;
+                give_node_value_csll(node1,(void*) &data1,sizeof(uint32_t));
+
+                add_node_to_tail_csll(&head1,node1);
+
+        }
+
+        create_node_csll(&node1);
+        data1 = 730;
+        give_node_value_csll(node1,(void*) &data1,sizeof(uint32_t));
+        add_node_in_index_n_csll(&head1,node1,1);
+
+        for(int i=0;i<10;i++)
+        {
+                printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+                // remove_head_node(&head1);
+                //remove_tail_node(&head1);
+                remove_node_in_index_n_csll(&head1,12);
+        }       
+
+        for(int i=0;i<11;i++)
+        {
+                printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+                remove_head_node_csll(&head1);
+        }       
+
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+
+        remove_head_node_csll(&head1);
+        remove_head_node_csll(&head1);
+        remove_head_node_csll(&head1);
+
+        free_linked_list_csll(&head1);
+
+        return ;
+}
+
+
+void single_ops_test()
+{
+        void *head1 = NULL;
+        uint32_t data1 = 2;
+
+        create_node_csll(&head1);
+        give_node_value_csll(head1,(void*) &data1,sizeof(uint32_t));
+        
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+
+        printf("%u\n", get_next_node_csll(head1));
+
+        printf("%u\n", head1);
+
+        printf("%u\n", *((uint32_t*)get_value_in_index_n_csll(head1,0)));
+
+        remove_head_node_csll(&head1);
+        remove_head_node_csll(&head1);
+        remove_head_node_csll(&head1);
+
+        free_linked_list_csll(&head1);
+
+        return ;
+
+
+}
+
+
+void free_linked_list_test()
+{
+
+        void *head1 = NULL;
+        void *node1 = NULL;
+        uint32_t data1 = 22;
+
+        create_node_csll(&head1);
+
+        give_node_value_csll(head1,(void*) &data1,sizeof(uint32_t));
+        // printf("%u\n", *((uint32_t*)get_value(head1)));
+
+   
+        for(int i=0;i<10;i++)
+        {
+                create_node_csll(&node1);
+                data1 = i;
+                give_node_value_csll(node1,(void*) &data1,sizeof(uint32_t));
+
+                add_node_to_tail_csll(&head1,node1);
+        }
+
+
+        free_linked_list_csll(&head1);
+
+
+        return ;
+}
+
+void simple_single_linked_list_test3()
+{
+
+        void *head1 = NULL;
+        void *node1 = NULL;
+        uint32_t data1 = 2;
+
+        create_node_csll(&head1);
+        give_node_value_csll(head1,(void*) &data1,sizeof(uint32_t));
+
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+
+        create_node_csll(&node1);
+        data1 = 3;
+        give_node_value_csll(node1,(void*) &data1,sizeof(uint32_t));
+        add_node_to_head_csll(&head1,node1);
+
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+     
+        // remove_node_in_index_n(&head1,1);
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+        remove_head_node_csll(&head1);
+        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+
+        free_linked_list_csll(&head1);
+
+        return ;
+
+
+}
+
+int main()
+{
+        // simple_single_linked_list_test();
+
+        //single_ops_test();
+        
+        //simple_single_linked_list_test2();
+        
+        //free_linked_list_test();
+        simple_single_linked_list_test3();
+
+        return 0;  
+}

--- a/tests/circularsinglelinkedlist_test.c
+++ b/tests/circularsinglelinkedlist_test.c
@@ -9,39 +9,49 @@
 void simple_single_linked_list_test()
 {
 
-        void *head1 = NULL;
-        void *node1 = NULL;
+        void *list1 = NULL;
+        void *node1,*node2 = NULL;
+        void *head = NULL;
         uint32_t data1 = 2;
 
-        create_node_csll(&head1);
-
-
-        give_node_value_csll(head1,(void*) &data1,sizeof(uint32_t));
-        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
-
-   
+        create_list_csll(&list1);
 
         create_node_csll(&node1);
-        data1 = 3;
+
+
+                
         give_node_value_csll(node1,(void*) &data1,sizeof(uint32_t));
+        printf("%u\n", *((uint32_t*)get_value_csll(node1)));
 
-        add_node_to_head_csll(&head1,node1);
+   
+        add_node_to_head_csll(&list1,node1);
 
 
-        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+        create_node_csll(&node2);
+        data1 = 3;
+        give_node_value_csll(node2,(void*) &data1,sizeof(uint32_t));
+
+        add_node_to_head_csll(&list1,node2);
+
+        head = get_head_node(list1);
+
+
+        printf("%u\n", *((uint32_t*)get_value_csll(head)));
      
-        remove_head_node_csll(&head1);
+        remove_head_node_csll(&list1);
 
-        printf("%u\n", *((uint32_t*)get_value_csll(head1)));
+        head = get_head_node(list1);
 
-        remove_head_node_csll(&head1);
-        remove_head_node_csll(&head1);
-        remove_head_node_csll(&head1);
+        printf("%u\n", *((uint32_t*)get_value_csll(head)));
+
+        remove_head_node_csll(&list1);
+        remove_head_node_csll(&list1);
+        remove_head_node_csll(&list1);
 
         return ;
 }
 
-
+/*
 void simple_single_linked_list_test2()
 {
 
@@ -184,16 +194,18 @@ void simple_single_linked_list_test3()
 
 }
 
+*/
+
 int main()
 {
-        // simple_single_linked_list_test();
+        simple_single_linked_list_test();
 
         //single_ops_test();
         
         //simple_single_linked_list_test2();
         
         //free_linked_list_test();
-        simple_single_linked_list_test3();
+        // simple_single_linked_list_test3();
 
         return 0;  
 }


### PR DESCRIPTION
Added support for circular single-linked lists. Solution uses a sentinel node, and therefore has a different syntax from other linked lists.